### PR TITLE
Add access token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Stick a TV on the wall, open a browser there and enjoy your TeamCity projects in
 ```javascript
   "Connection": {
     "Url": "http://your-teamcity-server/",
-    "AuthenticationMode": "BasicAuthentication" // or "Guest"
-    "Username": "your-teamcity-username",
-    "Password": "your-teamcity-password"
+    "AuthenticationMode": "BasicAuthentication" // or "Guest" or "AccessToken"
+    "Username": "your-teamcity-username", // if using Basic
+    "Password": "your-teamcity-password", // if using Basic
+    "AccessToken": "your-teamcity-accesstoken", // if using AccessToken
   }
 ```
   - OR add the following environment parameters: (watch the number of underscores!!!)
@@ -58,6 +59,7 @@ Stick a TV on the wall, open a browser there and enjoy your TeamCity projects in
     - TEAMCITYTHEATRE_CONNECTION__AUTHENTICATIONMODE
     - TEAMCITYTHEATRE_CONNECTION__USERNAME
     - TEAMCITYTHEATRE_CONNECTION__PASSWORD
+    - TEAMCITYTHEATRE_CONNECTION__ACCESSTOKEN
 
 3. (Optional) In appsettings.json, change the location of the configuration.json file or leave the default. This file will contain your views/tiles/etc.
 4. (Optional) In appsettings.json, change the logging configuration. It's quite verbose by default, but will never take more than 75MB of space.

--- a/src/TeamCityTheatre.Core/Client/TeamCityRestClientFactory.cs
+++ b/src/TeamCityTheatre.Core/Client/TeamCityRestClientFactory.cs
@@ -32,6 +32,14 @@ namespace TeamCityTheatre.Core.Client {
           };
           break;
         }
+
+        case AuthenticationMode.AccessToken: {
+          client = new RestClient {
+            BaseUrl = new Uri(new Uri(connectionOptions.Url), new Uri("app/rest", UriKind.Relative)),
+            Authenticator = new JwtAuthenticator(connectionOptions.AccessToken)
+          };
+          break;
+        }
         
         default:
           throw new ArgumentOutOfRangeException("Invalid connectionOptions.AuthenticationMode: " + connectionOptions.AuthenticationMode);

--- a/src/TeamCityTheatre.Core/Options/ConnectionOptions.cs
+++ b/src/TeamCityTheatre.Core/Options/ConnectionOptions.cs
@@ -4,9 +4,11 @@
     public AuthenticationMode AuthenticationMode { get; set; }
     public string Username { get; set; }
     public string Password { get; set; }
+    public string AccessToken { get; set; }
   }
 
   public enum AuthenticationMode {
+    AccessToken,
     BasicAuthentication,
     Guest
   }

--- a/src/TeamCityTheatre.Web/Program.cs
+++ b/src/TeamCityTheatre.Web/Program.cs
@@ -75,12 +75,19 @@ namespace TeamCityTheatre.Web {
         throw new Exception("Connection.Password is not present  and authenticationMode is set to BasicAuthentication");
       }
 
+      if (teamCityConnection.AuthenticationMode == AuthenticationMode.AccessToken && string.IsNullOrEmpty(teamCityConnection.AccessToken)) {
+        throw new Exception("Connection.AccessToken is not present and authenticationMode is set to AccessToken");
+      }
+
       logger.Information("Using TeamCity server    : " + teamCityConnection.Url);
       logger.Information("Using TeamCity auth mode : " + teamCityConnection.AuthenticationMode);
       logger.Information("Using TeamCity user      : " + teamCityConnection.Username);
       logger.Information("Using TeamCity password  : "
                          + teamCityConnection.Password?.FirstOrDefault()
                          + new string(teamCityConnection.Password?.Skip(1).Select(_ => '*').ToArray() ?? new char[0]));
+      logger.Information("Using TeamCity access token  : "
+                         + teamCityConnection.AccessToken?.FirstOrDefault()
+                         + new string(teamCityConnection.AccessToken?.Skip(1).Select(_ => '*').ToArray() ?? new char[0]));
     }
   }
 }


### PR DESCRIPTION
Adds the ability to use an Access Token generated in the TeamCity administration pages, rather than requiring a user's username and password.